### PR TITLE
[#567] ApplicationRouter 크래쉬 이슈 수정

### DIFF
--- a/MooyahoApp/MooyahoApp/Presentations/Root/ApplicationRootRouter.swift
+++ b/MooyahoApp/MooyahoApp/Presentations/Root/ApplicationRootRouter.swift
@@ -68,7 +68,7 @@ extension ApplicationRootRouter {
     }
     
     public func showRemindItem(_ itemID: String) -> Bool {
-        guard let root = self.window.rootViewController,
+        guard let root = self.window?.rootViewController,
               self.mainInteractor != nil
         else {
             return false

--- a/MooyahoApp/MooyahoApp/Presentations/Root/ApplicationViewModel.swift
+++ b/MooyahoApp/MooyahoApp/Presentations/Root/ApplicationViewModel.swift
@@ -87,6 +87,7 @@ public final class ApplicationViewModelImple: ApplicationViewModel {
             .disposed(by: self.disposeBag)
         
         self.fcmService.receiveReadmindMessage
+            .observe(on: MainScheduler.instance)
             .subscribe(onNext: { [weak self] message in
                 self?.handleRemindMessage(message)
             })


### PR DESCRIPTION
- https://console.firebase.google.com/u/0/project/breadroad-af5c0/crashlytics/app/ios:com.sudo.park.Mooyaho-iOS/issues/159eccca2a107b63eb48f91577d52732?time=last-seven-days&sessionEventKey=04184c67c49a48e6af79bec207af7c39_1652665071238123431
- 리마인드 메세지로 앱 시작시 실제 window 세팅되기 이전에(routeMain 불리기 이전에) 메세지가 처리되어 발생하는 문제
- window에 옵셔널 처리 추가 -> 이경우 처리 못한 메세지는 ApplicationViewModel의 pendingShowRemindMessage로 처리됨(기존로직)