### PR TITLE
[#580] share extension에서 아이템 추가 이후 복귀시 리스트 갱신 안되는 이슈 수정

### DIFF
--- a/DataStore/DataStore/Local/LocalStorage.swift
+++ b/DataStore/DataStore/Local/LocalStorage.swift
@@ -144,9 +144,9 @@ public protocol ReadItemLocalStorage {
     
     func toggleItemIsFavorite(_ id: String, isOn: Bool) -> Maybe<Void>
     
-    func fetchIsReloadCollectionsNeed() -> Bool
+    func fetchReloadNeedCollectionIDs() -> [String]
     
-    func updateIsReloadCollectionNeed(_ newValue: Bool)
+    func updateIsReloadNeedCollectionIDs(_ newValue: [String])
 }
 
 

--- a/DataStore/DataStore/Local/LocalStorageImple+ReadItem.swift
+++ b/DataStore/DataStore/Local/LocalStorageImple+ReadItem.swift
@@ -146,11 +146,11 @@ extension LocalStorageImple {
             .flatMap(thenReplace)
     }
     
-    public func fetchIsReloadCollectionsNeed() -> Bool {
-        return self.environmentStorage.fetchIsReloadCollectionsNeed()
+    public func fetchReloadNeedCollectionIDs() -> [String] {
+        return self.environmentStorage.fetchReloadNeedCollectionIDs()
     }
     
-    public func updateIsReloadCollectionNeed(_ newValue: Bool) {
-        self.environmentStorage.updateIsReloadCollectionNeed(newValue)
+    public func updateIsReloadNeedCollectionIDs(_ newValue: [String]) {
+        return self.environmentStorage.updateIsReloadNeedCollectionIDs(newValue)
     }
 }

--- a/DataStore/DataStore/Local/Storages+Implements/EnvironmentStorage.swift
+++ b/DataStore/DataStore/Local/Storages+Implements/EnvironmentStorage.swift
@@ -39,9 +39,9 @@ public protocol EnvironmentStorage {
     
     func replaceReadiingLinkIDs(_ values: [String])
     
-    func fetchIsReloadCollectionsNeed() -> Bool
+    func fetchReloadNeedCollectionIDs() -> [String]
     
-    func updateIsReloadCollectionNeed(_ newValue: Bool)
+    func updateIsReloadNeedCollectionIDs(_ newValue: [String])
     
     func isAddItemGuideEverShown() -> Bool
     
@@ -61,7 +61,7 @@ enum EnvironmentStorageKeys {
     case readItemLatestSortOrder
     case readitemCustomOrder(_ collectionID: String)
     case readingLinkIDs
-    case isReloadNeed
+    case reloadNeedCollectionIDs
     case addItemGuideEverShown
     
     var keyvalue: String {
@@ -82,8 +82,8 @@ enum EnvironmentStorageKeys {
         case .readingLinkIDs:
             return "readingLinkIDs".insertPrefixOrNot(prefix)
             
-        case .isReloadNeed:
-            return "isReloadNeed".insertPrefixOrNot(prefix)
+        case .reloadNeedCollectionIDs:
+            return "reloadNeedCollectionIDs".insertPrefixOrNot(prefix)
             
         case .addItemGuideEverShown:
             return "addItemGuideEverShown".insertPrefixOrNot(prefix)
@@ -98,7 +98,7 @@ enum EnvironmentStorageKeys {
             "readItemLatestSortOrder".insertPrefixOrNot(prefix),
             "readitemCustomOrder".insertPrefixOrNot(prefix),
             "readingLinkIDs".insertPrefixOrNot(prefix),
-            "isReloadNeed".insertPrefixOrNot(prefix),
+            "reloadNeedCollectionIDs".insertPrefixOrNot(prefix),
             "addItemGuideEverShown".insertPrefixOrNot(prefix)
         ]
     }
@@ -261,14 +261,15 @@ extension UserDefaults {
         _ = self.write(key.keyvalue, value: values)
     }
     
-    public func fetchIsReloadCollectionsNeed() -> Bool {
-        let key = EnvironmentStorageKeys.isReloadNeed
-        return self.bool(forKey: key.keyvalue)
+    public func fetchReloadNeedCollectionIDs() -> [String] {
+        let key = EnvironmentStorageKeys.reloadNeedCollectionIDs
+        let ids: Result<[String]?, Error> = self.get(key.keyvalue)
+        return (try? ids.get()) ?? []
     }
     
-    public func updateIsReloadCollectionNeed(_ newValue: Bool) {
-        let key = EnvironmentStorageKeys.isReloadNeed
-        self.set(newValue, forKey: key.keyvalue)
+    public func updateIsReloadNeedCollectionIDs(_ newValue: [String]) {
+        let key = EnvironmentStorageKeys.reloadNeedCollectionIDs
+        _ = self.write(key.keyvalue, value: newValue)
     }
     
     public func isAddItemGuideEverShown() -> Bool {

--- a/DataStore/DataStore/Repository+Implements/RepositoryImple+ReadItem.swift
+++ b/DataStore/DataStore/Repository+Implements/RepositoryImple+ReadItem.swift
@@ -232,11 +232,11 @@ extension ReadItemRepository where Self: ReadItemRepositryDefImpleDependency, Se
         return toggleOnRemote.switchOr(append: toggleOnLocal, witoutError: ())
     }
     
-    public func isReloadNeed() -> Bool {
-        return self.readItemLocal.fetchIsReloadCollectionsNeed()
+    public func reloadNeedCollectionIDs() -> [String] {
+        return self.readItemLocal.fetchReloadNeedCollectionIDs()
     }
     
-    public func updateIsReloadNeed(_ newValue: Bool) {
-        return self.readItemLocal.updateIsReloadCollectionNeed(newValue)
+    public func updateIsReloadNeedCollectionIDs(_ newValue: [String]) {
+        self.readItemLocal.updateIsReloadNeedCollectionIDs(newValue)
     }
 }

--- a/DataStore/DataStoreTests/Local/LocalStorageTests+ReadItem.swift
+++ b/DataStore/DataStoreTests/Local/LocalStorageTests+ReadItem.swift
@@ -406,13 +406,13 @@ extension LocalStorageTests_ReadItem {
     func testStorage_updateAndLoadIsNeedRealod() {
         // given
         // when
-        let isReloadNeedBeforeUpdate = self.local.fetchIsReloadCollectionsNeed()
-        self.local.updateIsReloadCollectionNeed(true)
-        let isReloadNeedAfterUpdate = self.local.fetchIsReloadCollectionsNeed()
+        let reloadNeedIDsBeforeUpdate = self.local.fetchReloadNeedCollectionIDs()
+        self.local.updateIsReloadNeedCollectionIDs(["c1", "c2"])
+        let reloadNeedIDsAfterUpdate = self.local.fetchReloadNeedCollectionIDs()
         
         // then
-        XCTAssertEqual(isReloadNeedBeforeUpdate, false)
-        XCTAssertEqual(isReloadNeedAfterUpdate, true)
+        XCTAssertEqual(reloadNeedIDsBeforeUpdate, [])
+        XCTAssertEqual(reloadNeedIDsAfterUpdate, ["c1", "c2"])
     }
 }
 

--- a/DataStore/DataStoreTests/Repositories/RepositoryTests+ReadItem.swift
+++ b/DataStore/DataStoreTests/Repositories/RepositoryTests+ReadItem.swift
@@ -895,25 +895,25 @@ extension RepositoryTests_ReadItem {
     
     func testRepository_loadIsReloadNeed() {
         // given
-        self.mockLocal.register(key: "fetchIsReloadCollectionsNeed") { true }
+        self.mockLocal.register(key: "fetchReloadNeedCollectionIDs") { ["some"] }
         
         // when
-        let isNeed = self.dummyRepository.isReloadNeed()
+        let needIDs = self.dummyRepository.reloadNeedCollectionIDs()
         
         // then
-        XCTAssertEqual(isNeed, true)
+        XCTAssertEqual(needIDs, ["some"])
     }
 
     func testRepository_updateIsReloadNeed() {
         // given
         let expect = expectation(description: "reload 필요여부 업데이트")
-        self.mockLocal.called(key: "updateIsReloadCollectionNeed") { args in
-            guard let isNeed = args as? Bool, isNeed else { return }
+        self.mockLocal.called(key: "updateIsReloadNeedCollectionIDs") { args in
+            guard let ids = args as? [String], ids == ["some"] else { return }
             expect.fulfill()
         }
         
         // when
-        self.dummyRepository.updateIsReloadNeed(true)
+        self.dummyRepository.updateIsReloadNeedCollectionIDs(["some"])
         
         // then
         self.wait(for: [expect], timeout: self.timeout)

--- a/DataStore/DataStoreTests/Stub/MockLocal.swift
+++ b/DataStore/DataStoreTests/Stub/MockLocal.swift
@@ -184,12 +184,12 @@ class MockLocal: LocalStorage, Mocking {
         self.verify(key: "updateLinkItemIsReading", with: isReading)
     }
     
-    func fetchIsReloadCollectionsNeed() -> Bool {
-        return self.resolve(key: "fetchIsReloadCollectionsNeed") ?? false
+    func fetchReloadNeedCollectionIDs() -> [String] {
+        return self.resolve(key: "fetchReloadNeedCollectionIDs") ?? []
     }
     
-    func updateIsReloadCollectionNeed(_ newValue: Bool) {
-        self.verify(key: "updateIsReloadCollectionNeed", with: newValue)
+    func updateIsReloadNeedCollectionIDs(_ newValue: [String]) {
+        self.verify(key: "updateIsReloadNeedCollectionIDs", with: newValue)
     }
     
     func readingLinkItemIDs() -> [String] {

--- a/Domain/Domain/Repositories/ReadItemRepository.swift
+++ b/Domain/Domain/Repositories/ReadItemRepository.swift
@@ -43,7 +43,7 @@ public protocol ReadItemRepository {
     
     func updateLinkItemIsReading(_ id: String)
     
-    func isReloadNeed() -> Bool
+    func reloadNeedCollectionIDs() -> [String]
     
-    func updateIsReloadNeed(_ newValue: Bool)
+    func updateIsReloadNeedCollectionIDs(_ newValue: [String])
 }

--- a/Domain/Domain/Usecases/Read/ReadItemSyncUsecase.swift
+++ b/Domain/Domain/Usecases/Read/ReadItemSyncUsecase.swift
@@ -11,17 +11,17 @@ import Foundation
 
 public protocol ReadItemSyncUsecase: AnyObject {
     
-    var isReloadNeed: Bool { get set }
+    var reloadNeedCollectionIDs: [String] { get set }
 }
 
 
 extension ReadItemUsecaseImple: ReadItemSyncUsecase {
     
-    public var isReloadNeed: Bool {
+    public var reloadNeedCollectionIDs: [String] {
         get {
-            return self.itemsRespoitory.isReloadNeed()
+            return self.itemsRespoitory.reloadNeedCollectionIDs()
         } set {
-            self.itemsRespoitory.updateIsReloadNeed(newValue)
+            self.itemsRespoitory.updateIsReloadNeedCollectionIDs(newValue)
         }
     }
 }

--- a/Domain/DomainTests/Doubles/StubReadItemRepository.swift
+++ b/Domain/DomainTests/Doubles/StubReadItemRepository.swift
@@ -116,12 +116,12 @@ class StubReadItemRepository: ReadItemRepository {
     
     func updateLinkItemIsReading(_ id: String) { }
     
-    var reloadNeedMocking: Bool = false
-    func isReloadNeed() -> Bool {
-        return self.reloadNeedMocking
+    var reloadNeedIDsMocking: [String] = []
+    func reloadNeedCollectionIDs() -> [String] {
+        return self.reloadNeedIDsMocking
     }
     
-    func updateIsReloadNeed(_ newValue: Bool) {
-        self.reloadNeedMocking = newValue
+    func updateIsReloadNeedCollectionIDs(_ newValue: [String]) {
+        self.reloadNeedIDsMocking = newValue
     }
 }

--- a/Domain/DomainTests/Usecases/ReadItemUsecaseTests.swift
+++ b/Domain/DomainTests/Usecases/ReadItemUsecaseTests.swift
@@ -55,7 +55,7 @@ class ReadItemUsecaseTests: BaseTestCase, WaitObservableEvents {
                      collectionMocking: ReadCollection? = nil,
                      customSortOrder: [String] = [],
                      copiedText: String? = nil,
-                     isReloadNeed: Bool = true) -> ReadItemUsecaseImple {
+                     reloadNeedIDs: [String] = []) -> ReadItemUsecaseImple {
         
         var repositoryScenario = StubReadItemRepository.Scenario()
         shouldfailLoadMyCollections.then {
@@ -67,7 +67,7 @@ class ReadItemUsecaseTests: BaseTestCase, WaitObservableEvents {
         repositoryScenario.ulrAndLinkItemMap = ["some": ReadLink.dummy(0, parent: nil)]
         let repositoryStub = SpyRepository(scenario: repositoryScenario)
         repositoryStub.collectionMocking = collectionMocking
-        repositoryStub.reloadNeedMocking = isReloadNeed
+        repositoryStub.reloadNeedIDsMocking = reloadNeedIDs
         self.spyRepository = repositoryStub
         
         let previewRepositoryStub = StubLinkPreviewRepository()
@@ -748,12 +748,12 @@ extension ReadItemUsecaseTests {
     
     func testUsecase_updateIsReloadNeed() {
         // given
-        let usecase = self.makeUsecase(isReloadNeed: true)
+        let usecase = self.makeUsecase(reloadNeedIDs: ["some"])
         
         // when + then
-        XCTAssertEqual(usecase.isReloadNeed, true)
-        usecase.isReloadNeed = false
-        XCTAssertEqual(usecase.isReloadNeed, false)
+        XCTAssertEqual(usecase.reloadNeedCollectionIDs, ["some"])
+        usecase.reloadNeedCollectionIDs = []
+        XCTAssertEqual(usecase.reloadNeedCollectionIDs, [])
     }
 }
 

--- a/MooyahoApp/ReadReminderShareExtension/ShareMain/ShareMainViewModel.swift
+++ b/MooyahoApp/ReadReminderShareExtension/ShareMain/ShareMainViewModel.swift
@@ -85,7 +85,11 @@ extension ShareMainViewModelImple {
 extension ShareMainViewModelImple: EditLinkItemSceneListenable {
     
     public func editReadLink(didEdit item: ReadLink) {
-        self.readItemSyncUsecase.isReloadNeed = true
+        let parentCollectionID = item.parentID ?? ReadCollection.rootID
+        let newIDs = self.readItemSyncUsecase.reloadNeedCollectionIDs
+            .filter { $0 != parentCollectionID }
+            + [parentCollectionID]
+        self.readItemSyncUsecase.reloadNeedCollectionIDs = newIDs
     }
     
     public func editReadLinkDidDismissed() {

--- a/MooyahoApp/ReadReminderShareExtensionTests/ShareMainViewModelTests.swift
+++ b/MooyahoApp/ReadReminderShareExtensionTests/ShareMainViewModelTests.swift
@@ -9,6 +9,8 @@
 import XCTest
 
 import RxSwift
+import Prelude
+import Optics
 
 import Domain
 import UnitTestHelpKit
@@ -98,12 +100,16 @@ extension ShareMainViewModelTests {
             return Maybe<(auth: Auth, member: Member?)>.just((Auth(userID: "some"), nil))
         }
         
-        // when
+        // when + then
         viewModel.showEditScene("https://dummy-url")
-        viewModel.editReadLink(didEdit: ReadLink.dummy(0))
         
-        // then
-        XCTAssertEqual(self.spyReadItemUsecase.isReloadNeed, true)
+        let dummy1 = ReadLink.dummy(0); let dummy2 = dummy1 |> \.parentID .~ "some"
+        
+        viewModel.editReadLink(didEdit: dummy1)
+        XCTAssertEqual(self.spyReadItemUsecase.reloadNeedCollectionIDs, [ReadCollection.rootID])
+        
+        viewModel.editReadLink(didEdit: dummy2)
+        XCTAssertEqual(self.spyReadItemUsecase.reloadNeedCollectionIDs, [ReadCollection.rootID, "some"])
     }
 }
 

--- a/Presentations/ReadItemScene/ReadItemSceneTests/ReadCollectionViewModelTests.swift
+++ b/Presentations/ReadItemScene/ReadItemSceneTests/ReadCollectionViewModelTests.swift
@@ -69,7 +69,7 @@ class ReadCollectionViewModelTests: BaseTestCase,  WaitObservableEvents {
                        customOrder: [String] = [],
                        hasParent: Bool = false,
                        inverseNavigation: CollectionInverseNavigationCoordinating? = nil,
-                       isReloadNeed: Bool = false) -> ReadCollectionViewItemsModelImple {
+                       reloadNeedIDsMocking: [String] = []) -> ReadCollectionViewItemsModelImple {
         
         let collectionID = isRootCollection ? nil : "some"
         let dummies = self.dummyCollectionItems.map { $0 |> \.parentID .~ collectionID }
@@ -86,7 +86,7 @@ class ReadCollectionViewModelTests: BaseTestCase,  WaitObservableEvents {
             |> \.customOrder .~ .success(customOrder)
             |> \.collectionInfo .~ .success(collection)
         let stubUsecase = PrivateStubReadItemUsecase(scenario: scenario)
-        stubUsecase.isReloadNeedMocking = isReloadNeed
+        stubUsecase.reloadNeedCollectionIDs = reloadNeedIDsMocking
         self.spyItemsUsecase = stubUsecase
         
         self.isShrinkModeMocking = { newValue in
@@ -1103,7 +1103,7 @@ extension ReadCollectionViewModelTests {
         // when
         let newCellViewModels = self.waitElements(expect, for: viewModel.cellViewModels.debug()) {
             viewModel.refreshList()
-            self.spyItemsUsecase.isReloadNeedMocking = false
+            self.spyItemsUsecase.reloadNeedCollectionIDs = []
             
             viewModel.reloadCollectionItemsIfNeed()
         }
@@ -1123,7 +1123,7 @@ extension ReadCollectionViewModelTests {
         let newCellViewModels = self.waitElements(expect, for: viewMdoel.cellViewModels) {
             viewMdoel.refreshList()
             self.spyItemsUsecase.scenario.collectionItems = .success([])
-            self.spyItemsUsecase.isReloadNeedMocking = true
+            self.spyItemsUsecase.reloadNeedCollectionIDs = ["some"]
             
             viewMdoel.reloadCollectionItemsIfNeed()
         }

--- a/UsecaseDoubles/UsecaseDoubles/Stubs/StubReadIttemUsecase.swift
+++ b/UsecaseDoubles/UsecaseDoubles/Stubs/StubReadIttemUsecase.swift
@@ -41,10 +41,10 @@ open class StubReadItemUsecase: ReadItemUsecase, ReadItemSyncUsecase {
         self.scenario = scenario
     }
     
-    public var isReloadNeedMocking: Bool = false
-    public var isReloadNeed: Bool {
-        get { self.isReloadNeedMocking }
-        set { self.isReloadNeedMocking = newValue }
+    public var reloadNeedCollectionIDsMocking: [String] = []
+    public var reloadNeedCollectionIDs: [String] {
+        get { self.reloadNeedCollectionIDsMocking }
+        set { self.reloadNeedCollectionIDsMocking = newValue }
     }
     
     open func loadMyItems() -> Observable<[ReadItem]> {


### PR DESCRIPTION
- 아이템 추가시 갱신 필요한 parentID 어레이 타입으로 저장
- 앱 복귀 이후에 해당되는 콜렉션 화면들의 갱신이 필요한 경우 갱신 + 갱신 필요 아이디 목록에서 제거