### PR TITLE
[#586] 웹뷰화면 점프로 진입한 경우 역방향 네비게이션 동작 안하는 이슈 수정(네비바 이슈)

### DIFF
--- a/Presentations/CommonPresenting/CommonPresenting/Utils/CollectionInverseNavigationCoordinator.swift
+++ b/Presentations/CommonPresenting/CommonPresenting/Utils/CollectionInverseNavigationCoordinator.swift
@@ -40,13 +40,14 @@ extension CollectionInverseNavigationCoordinator: CollectionInverseNavigationCoo
               navigationController.viewControllers.count > 1,
               let parentController = self.makeParent(parameter)
         else {
+            logger.print(level: .debug, "prepare parent called, but not this time, ")
             return
         }
         
-        logger.print(level: .debug, "inverse navigating prepare parent: \(parameter)")
         let lastIndex = navigationController.viewControllers.count
         var newControllers = navigationController.viewControllers + [parentController]
         newControllers.swapAt(lastIndex, lastIndex-1)
+        logger.print(level: .debug, "inverse navigating prepare parent: \(parameter), append parent totalCount: \(newControllers.count)")
         self.navigationController?.viewControllers = newControllers
     }
 }

--- a/Presentations/ReadItemScene/ReadItemScene/ReadCollection/ReadCollectionItemsViewController.swift
+++ b/Presentations/ReadItemScene/ReadItemScene/ReadCollection/ReadCollectionItemsViewController.swift
@@ -78,6 +78,7 @@ extension ReadCollectionItemsViewController {
         self.rx.viewDidAppear
             .subscribe(onNext: { [weak self] _ in
                 self?.viewModel.viewDidAppear()
+                self?.redrawNavigationItems()
             })
             .disposed(by: self.disposeBag)
         
@@ -111,6 +112,10 @@ extension ReadCollectionItemsViewController {
                 self?.viewModel.editCollection()
             })
             .disposed(by: self.disposeBag)
+    }
+    
+    private func redrawNavigationItems() {
+        self.navigationController?.navigationBar.isHidden = false
     }
 }
 

--- a/Presentations/ViewerScene/ViewerScene/InnerWebview/InnerWebViewViewModel.swift
+++ b/Presentations/ViewerScene/ViewerScene/InnerWebview/InnerWebViewViewModel.swift
@@ -185,7 +185,9 @@ extension InnerWebViewViewModelImple {
     
     public func jumpToCollection() {
         guard let item = self.subjects.item.value else { return }
-        self.listener?.innerWebView(reqeustJumpTo: item.parentID)
+        self.router.closeScene(animated: false) { [weak self] in
+            self?.listener?.innerWebView(reqeustJumpTo: item.parentID)
+        }
     }
 }
 


### PR DESCRIPTION
- 웹뷰에서 목록 점프시에 웹뷰 화면 닫고 이동하도록 수정
- 읽기목록 화면 viewDidAppear 이후에 네비바 다시그리게 하도록 수정