### PR TITLE
[#594] URL 인코딩 이슈 수정

### DIFF
--- a/DataStore/DataStore/Remote/RemoteImple+LinkPreview/LinkPreviewRemoteImple.swift
+++ b/DataStore/DataStore/Remote/RemoteImple+LinkPreview/LinkPreviewRemoteImple.swift
@@ -32,7 +32,7 @@ extension LinkPreviewRemoteImple: LinkPreviewRemote {
         return Maybe.create { [weak self] callback in
             guard let self = self else { return Disposables.create() }
             
-            guard let url = URL(string: url) else {
+            guard let url = url.asURL() else {
                 let error = RemoteErrors.invalidRequest(url)
                 callback(.error(error))
                 return Disposables.create()

--- a/Domain/Domain/Extensions+Utils/String+Extensions.swift
+++ b/Domain/Domain/Extensions+Utils/String+Extensions.swift
@@ -27,6 +27,11 @@ extension String {
         return predicate.evaluate(with: self)
     }
     
+    public func asURL(withEncoding allowCharSet: CharacterSet = .urlQueryAllowed) -> URL? {
+        let path = self.addingPercentEncoding(withAllowedCharacters: allowCharSet) ?? self
+        return URL(string: path)
+    }
+    
     public var localized: String {
         NSLocalizedString(self, bundle: Bundle.main, comment: "")
     }

--- a/Presentations/ViewerScene/ViewerScene/InnerWebview/InnerWebViewRouter.swift
+++ b/Presentations/ViewerScene/ViewerScene/InnerWebview/InnerWebViewRouter.swift
@@ -47,8 +47,7 @@ extension InnerWebViewRouter {
     
     // InnerWebViewRouting implements
     public func openSafariBrowser(_ address: String) {
-        
-        guard let url = URL(string: address) else { return }
+        guard let url = address.asURL() else { return }
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
     }
     

--- a/Presentations/ViewerScene/ViewerScene/InnerWebview/InnerWebViewViewController.swift
+++ b/Presentations/ViewerScene/ViewerScene/InnerWebview/InnerWebViewViewController.swift
@@ -144,7 +144,7 @@ extension InnerWebViewViewController {
     }
     
     private func loadWebPage(address: String) {
-        guard let url = URL(string: address) else { return }
+        guard let url = address.asURL() else { return }
         let urlRequest = URLRequest(url: url)
         self.webView.load(urlRequest)
     }


### PR DESCRIPTION
- 실제 사용하는 종단에서만 인코딩해 사용: 프리뷰 로드시, 웹뷰 로드시, 사파리 오픈시
- 그 외의 경우 입력된 값 이용 및 노툴